### PR TITLE
KeyStore EIP-712 support and fix compiler warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,15 +3,12 @@ name: test
 on:
   push:
     branches:
-      - "*"
+      - '*'
   pull_request:
     types: [opened, reopened, synchronize]
 
-permissions:
-  pull-requests: write
-  contents: "write"
-  id-token: "write"
-  issues: "write"
+env:
+  FOUNDRY_PROFILE: ci
 
 jobs:
   check:
@@ -36,28 +33,7 @@ jobs:
           forge build --sizes
         id: build
 
-      # Add any step generating a gas report to a temporary file named gasreport.ansi. For example:
-      - name: Run tests
-        run: forge test --gas-report > gasreport.ansi # <- this file name should be unique in your repository!
-        env:
-          # make fuzzing semi-deterministic to avoid noisy gas cost estimation
-          # due to non-deterministic fuzzing (but still use pseudo-random fuzzing seeds)
-          FOUNDRY_FUZZ_SEED: 0x${{ github.event.pull_request.base.sha || github.sha }}
-
-      - name: Compare gas reports
-        uses: Rubilmax/foundry-gas-diff@v3.16
-        with:
-          summaryQuantile: 0.9 # only display the 10% most significant gas diffs in the summary (defaults to 20%)
-          sortCriteria: avg,max # sort diff rows by criteria
-          sortOrders: desc,asc # and directions
-          ignore: test-foundry/**/* # filter out gas reports from specific paths (test/ is included by default)
-        id: gas_diff
-
-      - name: Add gas diff to sticky comment
-        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # delete the comment in case changes no longer impact gas costs
-          delete: ${{ !steps.gas_diff.outputs.markdown }}
-          message: ${{ steps.gas_diff.outputs.markdown }}
+      - name: Run Forge tests
+        run: |
+          forge test -vvv
+        id: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   pull-requests: write
-  contents: "read"
+  contents: "write"
   id-token: "write"
   issues: "write"
 
@@ -45,7 +45,7 @@ jobs:
           FOUNDRY_FUZZ_SEED: 0x${{ github.event.pull_request.base.sha || github.sha }}
 
       - name: Compare gas reports
-        uses: Rubilmax/foundry-gas-diff@v3.15
+        uses: Rubilmax/foundry-gas-diff@v3.16
         with:
           summaryQuantile: 0.9 # only display the 10% most significant gas diffs in the summary (defaults to 20%)
           sortCriteria: avg,max # sort diff rows by criteria

--- a/contracts/keystore/L1/KeyStore.sol
+++ b/contracts/keystore/L1/KeyStore.sol
@@ -3,16 +3,30 @@ pragma solidity ^0.8.17;
 
 import "./BaseKeyStore.sol";
 import "../interfaces/IKeystoreProof.sol";
+import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/interfaces/IERC1271.sol";
 
-contract KeyStore is BaseKeyStore, IKeystoreProof {
+contract KeyStore is BaseKeyStore, IKeystoreProof, EIP712 {
     using ECDSA for bytes32;
 
     event ApproveHash(address indexed guardian, bytes32 hash);
     event RejectHash(address indexed guardian, bytes32 hash);
 
     mapping(bytes32 => uint256) approvedHashes;
+
+    bytes32 private constant _TYPE_HASH_SET_KEY = keccak256("SetKey(bytes32 slot,uint256 nonce,bytes32 newKey)");
+    bytes32 private constant _TYPE_HASH_SET_GUARDIAN =
+        keccak256("SetGuardian(bytes32 slot,uint256 nonce,bytes32 newGuardianHash)");
+    bytes32 private constant _TYPE_HASH_SET_GUARDIAN_SAFE_PERIOD =
+        keccak256("SetGuardianSafePeriod(bytes32 slot,uint256 nonce,uint64 newGuardianSafePeriod)");
+    bytes32 private constant _TYPE_HASH_CANCEL_SET_GUARDIAN = keccak256("CancelSetGuardian(bytes32 slot,uint256 nonce)");
+    bytes32 private constant _TYPE_HASH_CANCEL_SET_GUARDIAN_SAFE_PERIOD =
+        keccak256("CancelSetGuardianSafePeriod(bytes32 slot,uint256 nonce)");
+    bytes32 private constant _TYPE_HASH_SOCIAL_RECOVERY =
+        keccak256("SocialRecovery(bytes32 slot,uint256 nonce,bytes32 newKey)");
+
+    constructor() EIP712("KeyStore", "1") {}
 
     function _keyGuard(bytes32 key) internal view override {
         super._keyGuard(key);
@@ -27,18 +41,62 @@ contract KeyStore is BaseKeyStore, IKeystoreProof {
         }
     }
 
-    function _validateKeySignature(bytes32 key, bytes32 signHash, bytes calldata keySignature)
-        internal
-        virtual
-        override
-    {
+    /**
+     * @dev Verify the signature of the `signKey`
+     * @param slot KeyStore slot
+     * @param slotNonce used to prevent replay attack
+     * @param signKey Current sign key
+     * @param action Action type, See ./interfaces/IKeyStore.sol: enum Action
+     * @param data {new key(Action.SET_KEY) | new guardian hash(Action.SET_GUARDIAN) | new guardian safe period(Action.SET_GUARDIAN_SAFE_PERIOD) | empty(Action.CANCEL_SET_GUARDIAN | Action.CANCEL_SET_GUARDIAN_SAFE_PERIOD )}
+     * @param keySignature `signature of current sign key`
+     *
+     * Note Implementer must revert if the signature is invalid
+     */
+    function verifySignature(
+        bytes32 slot,
+        uint256 slotNonce,
+        bytes32 signKey,
+        Action action,
+        bytes32 data,
+        bytes calldata keySignature
+    ) internal view override {
         address signer;
         assembly ("memory-safe") {
-            signer := key
+            signer := signKey
         }
-        (address recovered, ECDSA.RecoverError error) =
-            ECDSA.tryRecover(signHash.toEthSignedMessageHash(), keySignature);
-        if (error != ECDSA.RecoverError.NoError && signer != recovered) {
+
+        bytes32 digest;
+
+        if (action == Action.SET_KEY) {
+            // SetKey(bytes32 slot,uint256 nonce,bytes32 newKey)
+            digest = _hashTypedDataV4(keccak256(abi.encode(_TYPE_HASH_SET_KEY, slot, slotNonce, data)));
+        } else if (action == Action.SET_GUARDIAN) {
+            // SetGuardian(bytes32 slot,uint256 nonce,bytes32 newGuardianHash)
+            digest = _hashTypedDataV4(keccak256(abi.encode(_TYPE_HASH_SET_GUARDIAN, slot, slotNonce, data)));
+        } else if (action == Action.SET_GUARDIAN_SAFE_PERIOD) {
+            // SetGuardianSafePeriod(bytes32 slot,uint256 nonce,uint64 newGuardianSafePeriod)
+
+            // bytes32 -> uint64
+            uint64 newGuardianSafePeriod;
+            assembly ("memory-safe") {
+                newGuardianSafePeriod := data
+            }
+            digest = _hashTypedDataV4(
+                keccak256(abi.encode(_TYPE_HASH_SET_GUARDIAN_SAFE_PERIOD, slot, slotNonce, newGuardianSafePeriod))
+            );
+        } else if (action == Action.CANCEL_SET_GUARDIAN) {
+            // CancelSetGuardian(bytes32 slot,uint256 nonce)
+            digest = _hashTypedDataV4(keccak256(abi.encode(_TYPE_HASH_CANCEL_SET_GUARDIAN, slot, slotNonce)));
+        } else if (action == Action.CANCEL_SET_GUARDIAN_SAFE_PERIOD) {
+            // CancelSetGuardianSafePeriod(bytes32 slot,uint256 nonce)
+            digest =
+                _hashTypedDataV4(keccak256(abi.encode(_TYPE_HASH_CANCEL_SET_GUARDIAN_SAFE_PERIOD, slot, slotNonce)));
+        } else {
+            revert Errors.INVALID_DATA();
+        }
+
+        address recoveredAddress = ECDSA.recover(digest, keySignature);
+        if (signer != recoveredAddress) {
             revert Errors.INVALID_SIGNATURE();
         }
     }
@@ -96,15 +154,23 @@ contract KeyStore is BaseKeyStore, IKeystoreProof {
         emit RejectHash(msg.sender, hash);
     }
 
-    function _validateGuardianSignature(
-        bytes32 guardianHash,
+    /**
+     * @dev Verify the signature of the `guardian`
+     * @param slot KeyStore slot
+     * @param slotNonce used to prevent replay attack
+     * @param rawGuardian The raw data of the `guardianHash`
+     * @param newKey New key
+     * @param guardianSignature `signature of current guardian`
+     */
+    function verifyGuardianSignature(
+        bytes32 slot,
+        uint256 slotNonce,
         bytes calldata rawGuardian,
-        bytes32 signHash,
-        bytes calldata keySignature
-    ) internal virtual override {
-        if (keccak256(rawGuardian) != guardianHash) {
-            revert Errors.INVALID_DATA();
-        }
+        bytes32 newKey,
+        bytes calldata guardianSignature
+    ) internal view override {
+        bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(_TYPE_HASH_SOCIAL_RECOVERY, slot, slotNonce, newKey)));
+
         (address[] memory guardians, uint256 threshold, uint256 salt) =
             abi.decode(rawGuardian, (address[], uint256, uint256));
         (salt);
@@ -160,10 +226,10 @@ contract KeyStore is BaseKeyStore, IKeystoreProof {
         uint256 cursor = 0;
 
         uint256 skipCount = 0;
-        uint256 keySignatureLen = keySignature.length;
+        uint256 guardianSignatureLen = guardianSignature.length;
         for (uint256 i = 0; i < guardiansLen;) {
-            if (cursor >= keySignatureLen) break;
-            bytes calldata signatures = keySignature[cursor:];
+            if (cursor >= guardianSignatureLen) break;
+            bytes calldata signatures = guardianSignature[cursor:];
             assembly ("memory-safe") {
                 v := byte(0, calldataload(signatures.offset))
             }
@@ -181,14 +247,14 @@ contract KeyStore is BaseKeyStore, IKeystoreProof {
                     // read 's' as bytes4
                     let sigLen := shr(224, calldataload(add(signatures.offset, 1)))
 
-                    cursorEnd := add(5, sigLen) // see Note line 154
+                    cursorEnd := add(5, sigLen) // see Note line 219
                     cursor := add(cursor, cursorEnd)
                 }
 
                 bytes calldata dynamicData = signatures[5:cursorEnd];
                 {
                     (bool success, bytes memory result) = guardians[i].staticcall(
-                        abi.encodeWithSelector(IERC1271.isValidSignature.selector, signHash, dynamicData)
+                        abi.encodeWithSelector(IERC1271.isValidSignature.selector, digest, dynamicData)
                     );
                     require(
                         success && result.length == 32
@@ -203,10 +269,10 @@ contract KeyStore is BaseKeyStore, IKeystoreProof {
                         r: no set
                         s: no set
                  */
-                bytes32 key = _approveKey(guardians[i], signHash);
+                bytes32 key = _approveKey(guardians[i], digest);
                 require(approvedHashes[key] == 1, "hash not approved");
                 unchecked {
-                    cursor += 1; // see Note line 154
+                    cursor += 1; // see Note line 219
                 }
             } else if (v == 2) {
                 /* 
@@ -219,7 +285,7 @@ contract KeyStore is BaseKeyStore, IKeystoreProof {
                     // read 's' as bytes4
                     let skipTimes := shr(224, calldataload(add(signatures.offset, 1)))
 
-                    i := add(i, skipTimes) // see Note line 154
+                    i := add(i, skipTimes) // see Note line 219
                     skipCount := add(skipCount, add(skipTimes, 1))
                     cursor := add(cursor, 5)
                 }
@@ -234,15 +300,12 @@ contract KeyStore is BaseKeyStore, IKeystoreProof {
                     s := calldataload(add(signatures.offset, 1))
                     r := calldataload(add(signatures.offset, 33))
 
-                    cursor := add(cursor, 65) // see Note line 154
+                    cursor := add(cursor, 65) // see Note line 219
                 }
-                require(
-                    guardians[i] == ECDSA.recover(signHash.toEthSignedMessageHash(), v, r, s),
-                    "guardian signature invalid"
-                );
+                require(guardians[i] == ECDSA.recover(digest, v, r, s), "guardian signature invalid");
             }
             unchecked {
-                i++; // see Note line 154
+                i++; // see Note line 219
             }
         }
         if (guardiansLen - skipCount < threshold) {

--- a/contracts/keystore/L1/KeyStore.sol
+++ b/contracts/keystore/L1/KeyStore.sol
@@ -15,7 +15,8 @@ contract KeyStore is BaseKeyStore, IKeystoreProof, EIP712 {
 
     mapping(bytes32 => uint256) approvedHashes;
 
-    bytes32 private constant _TYPE_HASH_SET_KEY = keccak256("SetKey(bytes32 keyStoreSlot,uint256 nonce,bytes32 newKey)");
+    bytes32 private constant _TYPE_HASH_SET_KEY =
+        keccak256("SetKey(bytes32 keyStoreSlot,uint256 nonce,bytes32 newSigner)");
     bytes32 private constant _TYPE_HASH_SET_GUARDIAN =
         keccak256("SetGuardian(bytes32 keyStoreSlot,uint256 nonce,bytes32 newGuardianHash)");
     bytes32 private constant _TYPE_HASH_SET_GUARDIAN_SAFE_PERIOD =
@@ -25,7 +26,7 @@ contract KeyStore is BaseKeyStore, IKeystoreProof, EIP712 {
     bytes32 private constant _TYPE_HASH_CANCEL_SET_GUARDIAN_SAFE_PERIOD =
         keccak256("CancelSetGuardianSafePeriod(bytes32 keyStoreSlot,uint256 nonce)");
     bytes32 private constant _TYPE_HASH_SOCIAL_RECOVERY =
-        keccak256("SocialRecovery(bytes32 keyStoreSlot,uint256 nonce,bytes32 newKey)");
+        keccak256("SocialRecovery(bytes32 keyStoreSlot,uint256 nonce,bytes32 newSigner)");
 
     constructor() EIP712("KeyStore", "1") {}
 

--- a/contracts/keystore/L1/KeyStore.sol
+++ b/contracts/keystore/L1/KeyStore.sol
@@ -15,16 +15,17 @@ contract KeyStore is BaseKeyStore, IKeystoreProof, EIP712 {
 
     mapping(bytes32 => uint256) approvedHashes;
 
-    bytes32 private constant _TYPE_HASH_SET_KEY = keccak256("SetKey(bytes32 slot,uint256 nonce,bytes32 newKey)");
+    bytes32 private constant _TYPE_HASH_SET_KEY = keccak256("SetKey(bytes32 keyStoreSlot,uint256 nonce,bytes32 newKey)");
     bytes32 private constant _TYPE_HASH_SET_GUARDIAN =
-        keccak256("SetGuardian(bytes32 slot,uint256 nonce,bytes32 newGuardianHash)");
+        keccak256("SetGuardian(bytes32 keyStoreSlot,uint256 nonce,bytes32 newGuardianHash)");
     bytes32 private constant _TYPE_HASH_SET_GUARDIAN_SAFE_PERIOD =
-        keccak256("SetGuardianSafePeriod(bytes32 slot,uint256 nonce,uint64 newGuardianSafePeriod)");
-    bytes32 private constant _TYPE_HASH_CANCEL_SET_GUARDIAN = keccak256("CancelSetGuardian(bytes32 slot,uint256 nonce)");
+        keccak256("SetGuardianSafePeriod(bytes32 keyStoreSlot,uint256 nonce,uint64 newGuardianSafePeriod)");
+    bytes32 private constant _TYPE_HASH_CANCEL_SET_GUARDIAN =
+        keccak256("CancelSetGuardian(bytes32 keyStoreSlot,uint256 nonce)");
     bytes32 private constant _TYPE_HASH_CANCEL_SET_GUARDIAN_SAFE_PERIOD =
-        keccak256("CancelSetGuardianSafePeriod(bytes32 slot,uint256 nonce)");
+        keccak256("CancelSetGuardianSafePeriod(bytes32 keyStoreSlot,uint256 nonce)");
     bytes32 private constant _TYPE_HASH_SOCIAL_RECOVERY =
-        keccak256("SocialRecovery(bytes32 slot,uint256 nonce,bytes32 newKey)");
+        keccak256("SocialRecovery(bytes32 keyStoreSlot,uint256 nonce,bytes32 newKey)");
 
     constructor() EIP712("KeyStore", "1") {}
 

--- a/contracts/keystore/L1/interfaces/IKeyStore.sol
+++ b/contracts/keystore/L1/interfaces/IKeyStore.sol
@@ -1,6 +1,33 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.17;
 
+/**
+ * @dev Action of Signature
+ */
+enum Action
+{
+    /**
+     * @dev Set KeyStore.key to `new key`
+     */
+    SET_KEY,
+    /**
+     * @dev Set KeyStore.guardianHash to `new guardianHash`
+     */
+    SET_GUARDIAN,
+    /**
+     * @dev Cancel the pending guardianHash change
+     */
+    CANCEL_SET_GUARDIAN,
+    /**
+     * @dev Set KeyStore.guardianSafePeriod to `new guardianSafePeriod`
+     */
+    SET_GUARDIAN_SAFE_PERIOD,
+    /**
+     * @dev Cancel the pending guardianSafePeriod change
+     */
+    CANCEL_SET_GUARDIAN_SAFE_PERIOD
+}
+
 interface IKeyStore {
     /* 
     #######################################################################################################################################

--- a/contracts/modules/keystore/BlockVerifier.sol
+++ b/contracts/modules/keystore/BlockVerifier.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.17;
 library BlockVerifier {
     function extractStateRootAndTimestamp(bytes memory rlpBytes, bytes32 blockHash)
         internal
-        view
+        pure
         returns (bytes32 stateRoot, uint256 blockTimestamp, uint256 blockNumber)
     {
         assembly {

--- a/contracts/modules/keystore/MerklePatriciaVerifier.sol
+++ b/contracts/modules/keystore/MerklePatriciaVerifier.sol
@@ -68,10 +68,10 @@ library MerklePatriciaVerifier {
 
                 nodeKey = Rlp.toBytes32(currentNodeList[1]);
             } else {
-                require(false, "unexpected length array");
+                revert("unexpected length array");
             }
         }
-        require(false, "not enough proof nodes");
+        revert("not enough proof nodes");
     }
 
     function _nibblesToTraverse(bytes memory encodedPartialPath, bytes memory path, uint256 pathPtr)

--- a/contracts/paymaster/ERC20Paymaster.sol
+++ b/contracts/paymaster/ERC20Paymaster.sol
@@ -43,11 +43,10 @@ contract ERC20Paymaster is BasePaymaster {
         WALLET_FACTORY = _walletFactory;
     }
 
-    function setToken(
-        address[] calldata _tokens,
-        address[] calldata _tokenOracles,
-        uint32[] calldata _priceMarkups
-    ) external onlyOwner {
+    function setToken(address[] calldata _tokens, address[] calldata _tokenOracles, uint32[] calldata _priceMarkups)
+        external
+        onlyOwner
+    {
         require(
             _tokens.length == _tokenOracles.length && _tokenOracles.length == _priceMarkups.length,
             "Paymaster: length mismatch"
@@ -62,7 +61,7 @@ contract ERC20Paymaster is BasePaymaster {
             require(IOracle(_tokenOracle).decimals() == 8, "Paymaster: token oracle decimals must be 8");
             supportedToken[_token].priceMarkup = _priceMarkup;
             supportedToken[_token].tokenOracle = IOracle(_tokenOracle);
-            supportedToken[_token].tokenDecimals =  IERC20Metadata(_token).decimals();
+            supportedToken[_token].tokenDecimals = IERC20Metadata(_token).decimals();
 
             emit ConfigUpdated(_token, _tokenOracle, _priceMarkup);
         }
@@ -82,9 +81,9 @@ contract ERC20Paymaster is BasePaymaster {
         return address(supportedToken[token].tokenOracle) != address(0);
     }
 
-
     function _validatePaymasterUserOp(UserOperation calldata userOp, bytes32, uint256 requiredPreFund)
         internal
+        view
         override
         returns (bytes memory context, uint256 validationResult)
     {
@@ -167,7 +166,6 @@ contract ERC20Paymaster is BasePaymaster {
         }
     }
 
-
     function _postOp(PostOpMode mode, bytes calldata context, uint256 actualGasCost) internal override {
         if (mode == PostOpMode.postOpReverted) {
             return; // Do nothing here to not revert the whole bundle and harm reputation
@@ -181,7 +179,7 @@ contract ERC20Paymaster is BasePaymaster {
         // update oracle
         uint192 lasestTokenPrice = fetchPrice(supportedToken[token].tokenOracle);
         supportedToken[token].previousPrice = lasestTokenPrice;
-  
+
         emit UserOperationSponsored(sender, token, tokenRequiredFund, actualGasCost);
     }
 

--- a/script/CreateWalletDirect.s.sol
+++ b/script/CreateWalletDirect.s.sol
@@ -223,7 +223,7 @@ contract CreateWalletDirect is Script {
         );
     }
 
-    function loadEnvContract(string memory label) private returns (address) {
+    function loadEnvContract(string memory label) private view returns (address) {
         address contractAddress = vm.envAddress(label);
         require(contractAddress != address(0), string(abi.encodePacked(label, " not provided")));
         require(contractAddress.code.length > 0, string(abi.encodePacked(label, " needs be deployed")));

--- a/script/CreateWalletEntryPoint.s.sol
+++ b/script/CreateWalletEntryPoint.s.sol
@@ -113,7 +113,7 @@ contract CreateWalletEntryPoint is Script {
         entrypoint.handleOps(ops, payable(walletSigner));
     }
 
-    function logUserOp(UserOperation memory op) private {
+    function logUserOp(UserOperation memory op) private view {
         console.log("sender: ", op.sender);
         console.log("nonce: ", op.nonce);
         console.log("initCode: ");
@@ -138,7 +138,7 @@ contract CreateWalletEntryPoint is Script {
         require(addr == ECDSA.recover(hash.toEthSignedMessageHash(), signature));
     }
 
-    function loadEnvContract(string memory label) private returns (address) {
+    function loadEnvContract(string memory label) private view returns (address) {
         address contractAddress = vm.envAddress(label);
         require(contractAddress != address(0), string(abi.encodePacked(label, " not provided")));
         require(contractAddress.code.length > 0, string(abi.encodePacked(label, " needs be deployed")));

--- a/script/DeployHelper.sol
+++ b/script/DeployHelper.sol
@@ -99,7 +99,7 @@ abstract contract DeployHelper is Script {
         return NetWorkLib.getNetwork();
     }
 
-    function deploySingletonFactory() internal {
+    function deploySingletonFactory() internal view {
         if (address(SINGLETON_FACTORY).code.length == 0) {
             console.log("send 1 eth to SINGLE_USE_FACTORY_ADDRESS");
             string[] memory sendEthInputs = new string[](7);
@@ -110,23 +110,23 @@ abstract contract DeployHelper is Script {
             sendEthInputs[4] = LibString.toHexString(SINGLE_USE_FACTORY_ADDRESS);
             sendEthInputs[5] = "--value";
             sendEthInputs[6] = "1ether";
-            bytes memory sendEthRes = vm.ffi(sendEthInputs);
+            //bytes memory sendEthRes = vm.ffi(sendEthInputs);
             console.log("deploy singleton factory");
             string[] memory inputs = new string[](3);
             inputs[0] = "cast";
             inputs[1] = "publish";
             inputs[2] =
                 "0xf9016c8085174876e8008303c4d88080b90154608060405234801561001057600080fd5b50610134806100206000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80634af63f0214602d575b600080fd5b60cf60048036036040811015604157600080fd5b810190602081018135640100000000811115605b57600080fd5b820183602082011115606c57600080fd5b80359060200191846001830284011164010000000083111715608d57600080fd5b91908080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929550509135925060eb915050565b604080516001600160a01b039092168252519081900360200190f35b6000818351602085016000f5939250505056fea26469706673582212206b44f8a82cb6b156bfcc3dc6aadd6df4eefd204bc928a4397fd15dacf6d5320564736f6c634300060200331b83247000822470";
-            bytes memory res = vm.ffi(inputs);
+            //bytes memory res = vm.ffi(inputs);
         }
     }
 
-    function writeAddressToEnv(string memory label, address addr) internal {
+    function writeAddressToEnv(string memory label, address addr) internal pure {
         string[] memory inputs = new string[](4);
         inputs[0] = "node";
         inputs[1] = "script/ffi/save_to_env.js";
         inputs[2] = label;
         inputs[3] = vm.toString(addr);
-        bytes memory res = vm.ffi(inputs);
+        //bytes memory res = vm.ffi(inputs);
     }
 }

--- a/script/PaymasterDeployer.s.sol
+++ b/script/PaymasterDeployer.s.sol
@@ -54,7 +54,7 @@ contract PaymasterDeployer is Script, DeployHelper {
         }
     }
 
-    function deploy() private {
+    function deploy() private pure {
         revert("not implemented");
     }
 

--- a/script/SingletonFactory.s.sol
+++ b/script/SingletonFactory.s.sol
@@ -12,7 +12,7 @@ import "@account-abstraction/contracts/core/EntryPoint.sol";
 import "./DeployHelper.sol";
 
 contract SingletonFactory is Script, DeployHelper {
-    function run() public {
+    function run() public view {
         deploySingletonFactory();
     }
 }

--- a/test/soulwallet/modules/keystore/ArbitrumInboxMock.sol
+++ b/test/soulwallet/modules/keystore/ArbitrumInboxMock.sol
@@ -14,6 +14,7 @@ contract ArbitrumInboxMock is Test {
         uint256 maxFeePerGas,
         bytes calldata data
     ) public payable returns (uint256 _msgNum) {
+        (l2CallValue, maxSubmissionCost, excessFeeRefundAddress, callValueRefundAddress, gasLimit, maxFeePerGas);
         // modify to call l2 contract directly
         address l2Alias = AddressAliasHelper.applyL1ToL2Alias(address(msg.sender));
         vm.deal(l2Alias, 100 ether);
@@ -21,5 +22,6 @@ contract ArbitrumInboxMock is Test {
         (bool success,) = to.call(data);
         vm.stopPrank();
         require(success, "call failed");
+        return 0;
     }
 }

--- a/test/soulwallet/modules/keystore/OpKeystore.t.sol
+++ b/test/soulwallet/modules/keystore/OpKeystore.t.sol
@@ -8,11 +8,11 @@ import "@source/modules/keystore/OptimismKeyStoreProofModule/IL1Block.sol";
 import "./MockKeyStoreData.sol";
 
 contract MockL1Block is IL1Block, MockKeyStoreData {
-    function hash() external returns (bytes32) {
+    function hash() external view returns (bytes32) {
         return TEST_BLOCK_HASH;
     }
 
-    function number() external returns (uint256) {
+    function number() external view returns (uint256) {
         return TEST_BLOCK_NUMBER;
     }
 }

--- a/test/soulwallet/modules/keystore/OptimismKeyStoreModule.t.sol
+++ b/test/soulwallet/modules/keystore/OptimismKeyStoreModule.t.sol
@@ -11,11 +11,11 @@ import "./MockKeyStoreData.sol";
 import "@source/libraries/KeyStoreSlotLib.sol";
 
 contract MockL1Block is IL1Block, MockKeyStoreData {
-    function hash() external returns (bytes32) {
+    function hash() external view returns (bytes32) {
         return TEST_BLOCK_HASH;
     }
 
-    function number() external returns (uint256) {
+    function number() external view returns (uint256) {
         return TEST_BLOCK_NUMBER;
     }
 }


### PR DESCRIPTION
1. KeyStore EIP-712 support 

   - SET_KEY = keccak256("SetKey(bytes32 keyStoreSlot,uint256 nonce,bytes32 newSigner)");

   - SET_GUARDIAN = keccak256("SetGuardian(bytes32 keyStoreSlot,uint256 nonce,bytes32 newGuardianHash)");
   - SET_GUARDIAN_SAFE_PERIOD = keccak256("SetGuardianSafePeriod(bytes32 keyStoreSlot,uint256 nonce,uint64 newGuardianSafePeriod)");

   - CANCEL_SET_GUARDIAN = keccak256("CancelSetGuardian(bytes32 keyStoreSlot,uint256 nonce)");

   - CANCEL_SET_GUARDIAN_SAFE_PERIOD = keccak256("CancelSetGuardianSafePeriod(bytes32 keyStoreSlot,uint256 nonce)");

   - SOCIAL_RECOVERY = keccak256("SocialRecovery(bytes32 keyStoreSlot,uint256 nonce,bytes32 newSigner)");

2. fix compiler warnings

   - Unused local variable

   - Function state mutability
