### PR TITLE
Fix some issues

### DIFF
--- a/contracts/helper/SignatureValidator.sol
+++ b/contracts/helper/SignatureValidator.sol
@@ -28,6 +28,9 @@ abstract contract SignatureValidator is OwnerAuth, Validator {
 
         (guardHookInputData, validatorSignature) = SignatureDecoder.decodeSignature(rawSignature);
 
+        // To prevent potential attacks, prohibit the use of guardHookInputData with EIP1271 signatures.
+        require(guardHookInputData.length == 0);
+
         (validationData, recovered, success) = validator().recover1271Signature(rawHash, validatorSignature);
 
         if (!success) {

--- a/contracts/modules/SocialRecoveryModule/SocialRecoveryModule.sol
+++ b/contracts/modules/SocialRecoveryModule/SocialRecoveryModule.sol
@@ -15,13 +15,11 @@ contract SocialRecoveryModule is ISocialRecoveryModule, BaseModule {
     string public constant NAME = "Soulwallet Social Recovery Module";
     string public constant VERSION = "0.0.1";
 
-    // keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
     bytes32 private constant _DOMAIN_SEPARATOR_TYPEHASH =
-        0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f;
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
 
-    // keccak256("SocialRecovery(address wallet,address[] newOwners,uint256 nonce)");
     bytes32 private constant _SOCIAL_RECOVERY_TYPEHASH =
-        0x333ef7ecc7b8a82065578df0879cefc36c32344d49afdf1e0370a60babe64feb;
+        keccak256("SocialRecovery(address wallet,address[] newOwners,uint256 nonce)");
 
     bytes4 private constant _FUNC_RESET_OWNER = bytes4(keccak256("resetOwner(bytes32)"));
     bytes4 private constant _FUNC_RESET_OWNERS = bytes4(keccak256("resetOwners(bytes32[])"));

--- a/contracts/validator/BaseValidator.sol
+++ b/contracts/validator/BaseValidator.sol
@@ -11,17 +11,11 @@ import "../libraries/WebAuthn.sol";
 abstract contract BaseValidator is IValidator {
     using ECDSA for bytes32;
     using TypeConversion for address;
-    //keccak256(
-    //    "SoulWalletMessage(bytes32 message)"
-    //);
 
-    bytes32 private constant SOUL_WALLET_MSG_TYPEHASH =
-        0x04e6b5b1de6ba008d582849d4956d004d09a345fc11e7ba894975b5b56a4be66;
-    // keccak256(
-    //     "EIP712Domain(uint256 chainId,address verifyingContract)"
-    // );
+    bytes32 private constant SOUL_WALLET_MSG_TYPEHASH = keccak256("SoulWalletMessage(bytes32 message)");
+
     bytes32 private constant DOMAIN_SEPARATOR_TYPEHASH =
-        0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218;
+        keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");
 
     function _packSignatureHash(bytes32 hash, uint8 signatureType, uint256 validationData)
         internal


### PR DESCRIPTION
1. Security
   - SignatureValidator.sol: Prohibit the use of guardHookInputData in EIP1271 signatures.
2. Efficiency
   - SignatureDecoder.sol: When the calldata slice doesn't match the actual length at the index, it will revert, so we don't need additional checks.
3. Readability
   - BaseValidator.sol: DOMAIN_SEPARATOR_TYPEHASH no longer uses static constant, but is calculated at the time of contract deployment.